### PR TITLE
Difficulty changes map size

### DIFF
--- a/source/core/src/main/com/csse3200/game/areas/GameController.java
+++ b/source/core/src/main/com/csse3200/game/areas/GameController.java
@@ -110,17 +110,6 @@ public class GameController {
     }
 
     /**
-     * Initialise this Game Area to use the provided levelFactory without loading a saved state.
-     *
-     * @param levelFactory the provided levelFactory.
-     * @param shouldLoad   if the game should be loaded.
-     * @param player       the main player entity.
-     */
-    public GameController(GameArea gameArea, LevelFactory levelFactory, Entity player, Boolean shouldLoad) {
-        this(gameArea, levelFactory, player, false, new MapLoadConfig());
-    }
-
-    /**
      * Create the game area, including terrain, static entities (trees), and dynamic entities (player).
      */
     public void create() {

--- a/source/core/src/main/com/csse3200/game/areas/MainGameLevelFactory.java
+++ b/source/core/src/main/com/csse3200/game/areas/MainGameLevelFactory.java
@@ -16,7 +16,6 @@ import java.util.*;
  * This is the main game mode.
  */
 public class MainGameLevelFactory implements LevelFactory {
-    private static final int DEFAULT_MAP_SIZE = 40;
     private static final Logger log = LoggerFactory.getLogger(MainGameLevelFactory.class);
     private int levelNum;
     private final Map<String, Room> rooms;
@@ -71,9 +70,9 @@ public class MainGameLevelFactory implements LevelFactory {
     public Level create(int levelNumber) {
         String seed = "seed";
         // default seed for junit tests
+        log.debug("Creating level of size {}", config.mapSize);
         if (!shouldLoad) {
-            map = new LevelMap(seed + levelNumber, DEFAULT_MAP_SIZE);
-
+            map = new LevelMap(seed + levelNumber, config.mapSize);
         } else {
             // For loaded games, append the level number to the loaded seed
             map = new LevelMap(config.seed + config.currentLevel, config.mapSize);

--- a/source/core/src/main/com/csse3200/game/entities/configs/MapLoadConfig.java
+++ b/source/core/src/main/com/csse3200/game/entities/configs/MapLoadConfig.java
@@ -13,7 +13,7 @@ public class MapLoadConfig {
     public String seed = "seed";
     public int mapSize = SIZE_ON_MEDIUM;
 
-    private static final int SIZE_ON_MEDIUM = 40;
+    private static final int SIZE_ON_MEDIUM = 20;
 
     /**
      * Set map size based on difficulty. Harder difficulty corresponds to larger map size.
@@ -21,11 +21,11 @@ public class MapLoadConfig {
      * @return this instance
      */
     public MapLoadConfig setSizeFromDifficulty(Difficulty difficulty) {
-        // 30 on easy, 40 on medium, 50 on hard
-        mapSize = (int) (SIZE_ON_MEDIUM * (1.75 - difficulty.getMultiplier()));
+        // 10 on easy, 20 on medium, 30 on hard
+        mapSize = (int) (40 * (1.25 - difficulty.getMultiplier()));
         if (mapSize <= 0) {
             throw new IllegalStateException(
-                    "Difficulty is too easy and caused a negative-sized map");
+                    "Difficulty is too easy and caused an invalid map size");
         }
         return this;
     }

--- a/source/core/src/main/com/csse3200/game/entities/configs/MapLoadConfig.java
+++ b/source/core/src/main/com/csse3200/game/entities/configs/MapLoadConfig.java
@@ -1,13 +1,32 @@
 package com.csse3200.game.entities.configs;
 
+import com.csse3200.game.options.GameOptions.Difficulty;
+
 import java.util.ArrayList;
 import java.util.List;
 
 public class MapLoadConfig {
-    public List<String> roomsCompleted;
+    public List<String> roomsCompleted = new ArrayList<>();
     public List<String> shopRoomItems = new ArrayList<>();
-    public String currentLevel;
+    public String currentLevel = "0";
     public String currentRoom;
-    public String seed;
-    public int mapSize;
+    public String seed = "seed";
+    public int mapSize = SIZE_ON_MEDIUM;
+
+    private static final int SIZE_ON_MEDIUM = 40;
+
+    /**
+     * Set map size based on difficulty. Harder difficulty corresponds to larger map size.
+     * @param difficulty difficulty chosen by player.
+     * @return this instance
+     */
+    public MapLoadConfig setSizeFromDifficulty(Difficulty difficulty) {
+        // 30 on easy, 40 on medium, 50 on hard
+        mapSize = (int) (SIZE_ON_MEDIUM * (1.75 - difficulty.getMultiplier()));
+        if (mapSize <= 0) {
+            throw new IllegalStateException(
+                    "Difficulty is too easy and caused a negative-sized map");
+        }
+        return this;
+    }
 }

--- a/source/core/src/main/com/csse3200/game/entities/configs/MapLoadConfig.java
+++ b/source/core/src/main/com/csse3200/game/entities/configs/MapLoadConfig.java
@@ -14,6 +14,8 @@ public class MapLoadConfig {
     public int mapSize = SIZE_ON_MEDIUM;
 
     private static final int SIZE_ON_MEDIUM = 20;
+    private static final int SIZE_FACTOR = 40;
+    private static final double MUL_FACTOR = 1.25;
 
     /**
      * Set map size based on difficulty. Harder difficulty corresponds to larger map size.
@@ -22,7 +24,7 @@ public class MapLoadConfig {
      */
     public MapLoadConfig setSizeFromDifficulty(Difficulty difficulty) {
         // 10 on easy, 20 on medium, 30 on hard
-        mapSize = (int) (40 * (1.25 - difficulty.getMultiplier()));
+        mapSize = (int) (SIZE_FACTOR * (MUL_FACTOR - difficulty.getMultiplier()));
         if (mapSize <= 0) {
             throw new IllegalStateException(
                     "Difficulty is too easy and caused an invalid map size");

--- a/source/core/src/main/com/csse3200/game/screens/MainGameScreen.java
+++ b/source/core/src/main/com/csse3200/game/screens/MainGameScreen.java
@@ -46,6 +46,7 @@ public class MainGameScreen extends GameScreen {
 
         logger.debug("Initialising main game screen entities");
         MapLoadConfig mapConfig = new MapLoadConfig();
+        mapConfig.setSizeFromDifficulty(gameOptions.difficulty);
         mapConfig.currentLevel = "0";
         LevelFactory levelFactory = new MainGameLevelFactory(false, mapConfig);
         if (gameOptions.difficulty == TEST) {

--- a/source/core/src/test/com/csse3200/game/areas/Levels/MainGameLevelFactoryTest.java
+++ b/source/core/src/test/com/csse3200/game/areas/Levels/MainGameLevelFactoryTest.java
@@ -1,30 +1,31 @@
 package com.csse3200.game.areas.Levels;
 
-import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.csse3200.game.areas.Level;
 import com.csse3200.game.areas.LevelFactory;
 import com.csse3200.game.areas.MainGameLevelFactory;
 import com.csse3200.game.components.CameraComponent;
-import com.csse3200.game.files.FileLoader;
+import com.csse3200.game.entities.configs.MapLoadConfig;
+import com.csse3200.game.extensions.GameExtension;
+import com.csse3200.game.options.GameOptions.Difficulty;
 import com.csse3200.game.rendering.RenderService;
 import com.csse3200.game.services.ResourceService;
 import com.csse3200.game.services.ServiceLocator;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
 
-import java.util.*;
-
+@ExtendWith(GameExtension.class)
 class MainGameLevelFactoryTest {
 
     private LevelFactory levelFactory;
@@ -47,7 +48,7 @@ class MainGameLevelFactoryTest {
         // Set up ResourceService (or mock it if necessary)
         ServiceLocator.registerResourceService(new ResourceService());
 
-        levelFactory = new MainGameLevelFactory(false, null);
+        levelFactory = new MainGameLevelFactory(false, new MapLoadConfig());
     }
 
     @AfterEach
@@ -114,4 +115,21 @@ void testCreateMultipleLevels() {
     assertTrue(level1Rooms.size() > 1, "Level 1 should have multiple rooms");
     assertTrue(level2Rooms.size() > 1, "Level 2 should have multiple rooms");
     assertTrue(level3Rooms.size() > 1, "Level 3 should have multiple rooms");
-}}
+}
+
+    @Test
+    void harderDifficultyGivesBiggerLevel() {
+        LevelFactory easyFactory = new MainGameLevelFactory(
+                false, new MapLoadConfig().setSizeFromDifficulty(Difficulty.EASY));
+        LevelFactory mediumFactory = new MainGameLevelFactory(
+                false, new MapLoadConfig().setSizeFromDifficulty(Difficulty.MEDIUM));
+        LevelFactory hardFactory = new MainGameLevelFactory(
+                false, new MapLoadConfig().setSizeFromDifficulty(Difficulty.HARD));
+        assertTrue(easyFactory.create(0).getMap().getMapSize()
+                < mediumFactory.create(0).getMap().getMapSize(),
+                "Easy level should be smaller than medium");
+        assertTrue(mediumFactory.create(0).getMap().getMapSize()
+                        < hardFactory.create(0).getMap().getMapSize(),
+                "Medium level should be smaller than hard");
+    }
+}


### PR DESCRIPTION
# Description

- Difficulty changes map size
  - 30 on easy, 40 on medium, 50 on hard
- MapLoadConfig now stores default map settings
- Unit test added

Closes #469 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] See "FINE" log output from MainGameLevelFactory (need to change logging.properties). The map size will be shown here. Map size will change with the difficulty.
- [x] Load a game. The map size will match the loaded game.
- [x] Unit test added

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
