### PR TITLE
Remove menu smells, how to play screen scales

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/howtoplaymenu/HowToPlayMenuDisplay.java
+++ b/source/core/src/main/com/csse3200/game/components/howtoplaymenu/HowToPlayMenuDisplay.java
@@ -40,11 +40,12 @@ public class HowToPlayMenuDisplay extends UIComponent {
 
         rootTable = new Table();
         rootTable.setFillParent(true);
+        rootTable.defaults().expandX().pad(5f);
 
-        rootTable.add(title).expandX().top().padTop(20f);
+        rootTable.add(title).expandX();
 
-        rootTable.row().padTop(30f);
-        rootTable.add(howToPlayTable).expandX().expandY();
+        rootTable.row().padTop(20f);
+        rootTable.add(howToPlayTable).growX();
 
         rootTable.row();
         rootTable.add(menuBtns).fillX();
@@ -55,27 +56,23 @@ public class HowToPlayMenuDisplay extends UIComponent {
     private Table makeHowToPlayTable() {
         Label instruction = new Label("User Guide: ", skin);
 
-        String[][] paragraphs = {{
+        String[] text = {
                 "Beast Breakout is a top-down dungeon crawler game, presented using "
-                        + "two-dimensional sprites, in which the player controls",
-                "an unnamed character in a non-specific facility."
-            }, {
+                        + "two-dimensional sprites, in which the player controls an unnamed "
+                        + "character in a non-specific facility.",
                 "On each floor of the facility, the player must fight enraged animals in a room "
-                        + "before continuing onto the next room. This is",
-                "most commonly done by the character's melee or ranged weapon in the style of a "
-                        + "twin-stick shooter."
-            }, {
+                        + "before continuing onto the next room. This is most commonly done by "
+                        + "the character's melee or ranged weapon in the style of a "
+                        + "twin-stick shooter.",
                 "Other methods of defeating enemies become possible as the character gains "
-                        + "power-ups, items that are automatically worn",
-                "by the player-character when picked up that can alter the character's core "
+                        + "power-ups, items that are automatically worn by the player-character "
+                        + "when picked up that can alter the character's core "
                         + "attributes, such as increasing health or the",
-                "strength of their weapons, or cause additional side effects."
-            }, {
+                "strength of their weapons, or cause additional side effects.",
                 "When the player loses all of their health the game ends in permadeath and the "
-                        + "player must start over from a freshly-",
-                "generated dungeon. Each floor of the dungeon includes a boss which the player "
-                        + "must defeat before continuing to the next level."
-            }
+                        + "player must start over from a freshly-generated dungeon. Each floor of "
+                        + "the dungeon includes a boss which the player must defeat before "
+                        + "continuing to the next level."
         };
         TextButton animalBtn = new TextButton("About Animals", skin);
 
@@ -100,57 +97,21 @@ public class HowToPlayMenuDisplay extends UIComponent {
 
         // Position components on the table
         Table table = new Table();
-        table.add(instruction).left().padRight(10f);
-        table.row().padTop(40f);
+        table.defaults().expandX().pad(10f).left();
+        table.add(instruction);
+        table.row().padTop(20f);
 
-        for (String[] paragraph : paragraphs) {
-            for (int i = 0; i < paragraph.length; i++) {
-                String line = paragraph[i];
-                Label label = new Label(line, skin);
-                table.add(label).left().expandX();
-
-                // Different padding for end of paragraph
-                boolean lastLine = (i + 1 == paragraph.length);
-                table.row().padTop(lastLine ? 40f : 10f);
-            }
+        for (String line : text) {
+            Label label = new Label(line, skin);
+            label.setWrap(true);
+            table.add(label).left().fillX();
+            table.row().pad(10f);
         }
-        table.add(animalBtn).left().expandX();
+        table.add(animalBtn);
         table.row().padTop(10f);
-        table.add(weaponBtn).left().expandX();
-
-
-        // todo look into word wrap so we don't need this many labels
+        table.add(weaponBtn);
 
         return table;
-    }
-
-    private StringDecorator<Graphics.DisplayMode> getActiveMode(Array<StringDecorator<Graphics.DisplayMode>> modes) {
-        Graphics.DisplayMode active = Gdx.graphics.getDisplayMode();
-
-        for (StringDecorator<Graphics.DisplayMode> stringMode : modes) {
-            Graphics.DisplayMode mode = stringMode.object;
-            if (active.width == mode.width
-                    && active.height == mode.height
-                    && active.refreshRate == mode.refreshRate) {
-                return stringMode;
-            }
-        }
-        return null;
-    }
-
-    private Array<StringDecorator<Graphics.DisplayMode>> getDisplayModes(Graphics.Monitor monitor) {
-        Graphics.DisplayMode[] displayModes = Gdx.graphics.getDisplayModes(monitor);
-        Array<StringDecorator<Graphics.DisplayMode>> arr = new Array<>();
-
-        for (Graphics.DisplayMode displayMode : displayModes) {
-            arr.add(new StringDecorator<>(displayMode, this::prettyPrint));
-        }
-
-        return arr;
-    }
-
-    private String prettyPrint(Graphics.DisplayMode displayMode) {
-        return displayMode.width + "x" + displayMode.height + ", " + displayMode.refreshRate + "hz";
     }
 
     private Table makeMenuBtns() {
@@ -178,14 +139,6 @@ public class HowToPlayMenuDisplay extends UIComponent {
     }
     private void weaponMenu() {
         game.setScreen(GdxGame.ScreenType.WEAPONS);
-    }
-
-    private Integer parseOrNull(String num) {
-        try {
-            return Integer.parseInt(num, 10);
-        } catch (NumberFormatException e) {
-            return null;
-        }
     }
 
     @Override

--- a/source/core/src/main/com/csse3200/game/components/howtoplaymenu/WeaponDisplay.java
+++ b/source/core/src/main/com/csse3200/game/components/howtoplaymenu/WeaponDisplay.java
@@ -21,11 +21,6 @@ public class WeaponDisplay extends UIComponent{
     private final GdxGame game;
 
     private Table rootTable;
-    private TextField fpsText;
-    private CheckBox fullScreenCheck;
-    private CheckBox vsyncCheck;
-    private Slider uiScaleSlider;
-    private SelectBox<StringDecorator<Graphics.DisplayMode>> displayModeSelect;
 
     public WeaponDisplay(GdxGame game) {
         super();
@@ -93,31 +88,6 @@ public class WeaponDisplay extends UIComponent{
         return table;
     }
 
-    private StringDecorator<Graphics.DisplayMode> getActiveMode(Array<StringDecorator<Graphics.DisplayMode>> modes) {
-        Graphics.DisplayMode active = Gdx.graphics.getDisplayMode();
-
-        for (StringDecorator<Graphics.DisplayMode> stringMode : modes) {
-            Graphics.DisplayMode mode = stringMode.object;
-            if (active.width == mode.width
-                    && active.height == mode.height
-                    && active.refreshRate == mode.refreshRate) {
-                return stringMode;
-            }
-        }
-        return null;
-    }
-
-    private Array<StringDecorator<Graphics.DisplayMode>> getDisplayModes(Graphics.Monitor monitor) {
-        Graphics.DisplayMode[] displayModes = Gdx.graphics.getDisplayModes(monitor);
-        Array<StringDecorator<Graphics.DisplayMode>> arr = new Array<>();
-
-        for (Graphics.DisplayMode displayMode : displayModes) {
-            arr.add(new StringDecorator<>(displayMode, this::prettyPrint));
-        }
-
-        return arr;
-    }
-
     private String prettyPrint(Graphics.DisplayMode displayMode) {
         return displayMode.width + "x" + displayMode.height + ", " + displayMode.refreshRate + "hz";
     }
@@ -146,7 +116,6 @@ public class WeaponDisplay extends UIComponent{
     @Override
     protected void draw(SpriteBatch batch) {
         // draw is handled by the stage
-
     }
 
     @Override

--- a/source/core/src/main/com/csse3200/game/components/howtoplaymenu/WeaponDisplay.java
+++ b/source/core/src/main/com/csse3200/game/components/howtoplaymenu/WeaponDisplay.java
@@ -139,31 +139,8 @@ public class WeaponDisplay extends UIComponent{
         return table;
     }
 
-    private void applyChanges() {
-        UserSettings.Settings settings = UserSettings.get();
-
-        Integer fpsVal = parseOrNull(fpsText.getText());
-        if (fpsVal != null) {
-            settings.fps = fpsVal;
-        }
-        settings.fullscreen = fullScreenCheck.isChecked();
-        settings.uiScale = uiScaleSlider.getValue();
-        settings.displayMode = new UserSettings.DisplaySettings(displayModeSelect.getSelected().object);
-        settings.vsync = vsyncCheck.isChecked();
-
-        UserSettings.set(settings, true);
-    }
-
     private void exitMenu() {
         game.setScreen(GdxGame.ScreenType.HOW_TO_PLAY);
-    }
-
-    private Integer parseOrNull(String num) {
-        try {
-            return Integer.parseInt(num, 10);
-        } catch (NumberFormatException e) {
-            return null;
-        }
     }
 
     @Override

--- a/source/core/src/main/com/csse3200/game/components/mainmenu/MainMenuActions.java
+++ b/source/core/src/main/com/csse3200/game/components/mainmenu/MainMenuActions.java
@@ -40,7 +40,7 @@ public class MainMenuActions extends Component {
      */
     private void onPlayerSelect(Difficulty difficulty) {
         logger.info("Going to player selection");
-        game.gameOptions.difficulty = difficulty;
+        game.gameOptions.setDifficulty(difficulty);
         game.setScreen(ScreenType.PLAYER_SELECT);
     }
 

--- a/source/core/src/main/com/csse3200/game/components/mainmenu/MainMenuDisplay.java
+++ b/source/core/src/main/com/csse3200/game/components/mainmenu/MainMenuDisplay.java
@@ -12,14 +12,11 @@ import com.csse3200.game.entities.configs.PlayerConfig;
 import com.csse3200.game.files.FileLoader;
 import com.csse3200.game.files.UserSettings;
 import com.csse3200.game.options.GameOptions.Difficulty;
-import com.csse3200.game.services.ServiceLocator;
 import com.csse3200.game.ui.UIComponent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.EnumMap;
-import java.util.HashMap;
 
 import static com.csse3200.game.services.ServiceLocator.getResourceService;
 
@@ -39,7 +36,7 @@ public class MainMenuDisplay extends UIComponent {
      */
     private Table diffBtnsTable;
 
-    private Image bg_logo;
+    private Image backgroundLogo;
 
     @Override
     public void create() {
@@ -66,7 +63,7 @@ public class MainMenuDisplay extends UIComponent {
 
         table = new Table();
         table.setFillParent(true);
-        bg_logo = new Image(
+        backgroundLogo = new Image(
                 getResourceService().getAsset("images/bg_logo.png", Texture.class));
 
         diffBtnsTable = new Table();
@@ -88,8 +85,8 @@ public class MainMenuDisplay extends UIComponent {
             settings.displayMode = new UserSettings.DisplaySettings(Gdx.graphics.getDisplayMode());
         }
 
-        bg_logo.setSize(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
-        bg_logo.setPosition(0, 0);
+        backgroundLogo.setSize(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+        backgroundLogo.setPosition(0, 0);
 
         // Triggers an event when the button is pressed
 
@@ -97,7 +94,7 @@ public class MainMenuDisplay extends UIComponent {
                 new ChangeListener() {
                     @Override
                     public void changed(ChangeEvent event, Actor actor) {
-                        logger.debug("{} difficulty button clicked", difficulty.toString());
+                        logger.debug("{} difficulty button clicked", difficulty);
                         entity.getEvents().trigger(
                                 "player_select", difficulty);
                     }
@@ -167,7 +164,7 @@ public class MainMenuDisplay extends UIComponent {
             table.add(button);
             table.row();
         }
-        stage.addActor(bg_logo);
+        stage.addActor(backgroundLogo);
         stage.addActor(table);
     }
 
@@ -189,6 +186,6 @@ public class MainMenuDisplay extends UIComponent {
     }
 
     public void resize(int width, int height) {
-        bg_logo.setSize(width, height);
+        backgroundLogo.setSize(width, height);
     }
 }

--- a/source/core/src/main/com/csse3200/game/components/screendisplay/IntroCutsceneDisplay.java
+++ b/source/core/src/main/com/csse3200/game/components/screendisplay/IntroCutsceneDisplay.java
@@ -27,6 +27,7 @@ public class IntroCutsceneDisplay extends UIComponent {
     private static final Logger logger = LoggerFactory.getLogger(IntroCutsceneDisplay.class);
     private static final int Y_PADDING_BUTTON = 40;
     private static final int X_PADDING_BUTTON = 20;
+    private static final String ACTION_STYLE = "action";
 
     private final GdxGame game;
     private Table table;
@@ -122,7 +123,7 @@ public class IntroCutsceneDisplay extends UIComponent {
             buttonTable.setFillParent(true);
             buttonTable.bottom().padBottom(Y_PADDING_BUTTON); // Position the buttons at the bottom with padding
 
-            Button startGameBtn = new TextButton("Start Game", skin, "action");
+            Button startGameBtn = new TextButton("Start Game", skin, ACTION_STYLE);
             startGameBtn.addListener(new ChangeListener() {
                 @Override
                 public void changed(ChangeEvent event, Actor actor) {
@@ -141,11 +142,11 @@ public class IntroCutsceneDisplay extends UIComponent {
         buttonTable.bottom().padBottom(Y_PADDING_BUTTON); // Position the buttons at the bottom with padding
 
         // Show the "Skip" button if not on the last page
-        Button skipBtn = new TextButton("Skip", skin, "action");
+        Button skipBtn = new TextButton("Skip", skin, ACTION_STYLE);
         skipBtn.addListener(new ChangeListener() {
             @Override
             public void changed(ChangeEvent event, Actor actor) {
-                onSkip(); // Skip to the last page
+                skipToLastPage(); // Skip to the last page
             }
         });
         buttonTable.add(skipBtn).padRight(X_PADDING_BUTTON); // Add skip button with padding to the right
@@ -158,7 +159,9 @@ public class IntroCutsceneDisplay extends UIComponent {
     }
 
     private void addNextButton(Table buttonTable) {
-        Button nextBtn = new TextButton(currentPage == cutsceneTextures.length - 1 ? "Start Game" : "Next", skin, "action");
+        Button nextBtn = new TextButton(
+                currentPage == cutsceneTextures.length - 1 ? "Start Game" : "Next",
+                skin, ACTION_STYLE);
         nextBtn.addListener(new ChangeListener() {
             @Override
             public void changed(ChangeEvent event, Actor actor) {
@@ -171,12 +174,8 @@ public class IntroCutsceneDisplay extends UIComponent {
             }
         });
 
-        buttonTable.add(nextBtn).padLeft(X_PADDING_BUTTON); // Add next button with padding to the left
-    }
-
-    private void onSkip() {
-        currentPage = cutsceneTextures.length - 1; // Skip to the last page
-        updateCutscene(); // Update the cutscene
+        buttonTable.add(nextBtn).padLeft(X_PADDING_BUTTON); // Add next button with padding to the
+        // left
     }
 
     private void skipToLastPage() {

--- a/source/core/src/main/com/csse3200/game/components/screendisplay/IntroCutsceneDisplay.java
+++ b/source/core/src/main/com/csse3200/game/components/screendisplay/IntroCutsceneDisplay.java
@@ -46,6 +46,8 @@ public class IntroCutsceneDisplay extends UIComponent {
 
     @Override
     public void create() {
+
+        logger.debug("Creating cutscene");
         super.create();
         loadTextures();
 
@@ -76,6 +78,9 @@ public class IntroCutsceneDisplay extends UIComponent {
     }
 
     private void loadTextures() {
+
+        logger.debug("Loading cutscene textures");
+
         // Define the texture file paths in a fixed array
         String[] texturePaths = {
                 "images/screen/cutscene1.jpg",
@@ -180,11 +185,13 @@ public class IntroCutsceneDisplay extends UIComponent {
     }
 
     private void onStart() {
+        logger.debug("Finished cutscene, going to main game");
         game.setScreen(GdxGame.ScreenType.MAIN_GAME);
     }
 
     @Override
     public void dispose() {
+        logger.debug("Disposing cutscene textures");
         for (Texture texture : cutsceneTextures) {
             texture.dispose();
         }

--- a/source/core/src/main/com/csse3200/game/components/screendisplay/PlayerSelectDisplay.java
+++ b/source/core/src/main/com/csse3200/game/components/screendisplay/PlayerSelectDisplay.java
@@ -142,7 +142,7 @@ public class PlayerSelectDisplay extends UIComponent {
 
     private void playerSelected(String name) {
         logger.info("Player chosen: {}", name);
-        game.gameOptions.playerFactory = playerFactoryFactory.create(name);
+        game.gameOptions.setPlayerFactory(playerFactoryFactory.create(name));
         game.setScreen(ScreenType.CUTSCENE);
     }
 

--- a/source/core/src/main/com/csse3200/game/components/settingsmenu/SettingsMenuDisplay.java
+++ b/source/core/src/main/com/csse3200/game/components/settingsmenu/SettingsMenuDisplay.java
@@ -24,26 +24,24 @@ import com.csse3200.game.utils.StringDecorator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 /**
  * Settings menu display and logic. If you bork the settings, they can be changed manually in
  * CSSE3200Game/settings.json under your home directory (This is C:/users/[username] on Windows).
  */
 public class SettingsMenuDisplay extends UIComponent {
+
     private static final Logger logger = LoggerFactory.getLogger(SettingsMenuDisplay.class);
+    private static final String PERCENT_FORMAT = "%.0f%%";
     private final GdxGame game;
 
     private Table rootTable;
     private TextField fpsText;
     private CheckBox fullScreenCheck;
     private CheckBox vsyncCheck;
-    private Slider uiScaleSlider;
     private Slider musicVolumeSlider;
     private Slider soundVolumeSlider;
     private CheckBox muteCheck;
     private SelectBox<StringDecorator<DisplayMode>> displayModeSelect;
-    private SelectBox<String> actionSelect;
-    private SelectBox<String> keySelect;
 
     public SettingsMenuDisplay(GdxGame game) {
         super();
@@ -91,20 +89,15 @@ public class SettingsMenuDisplay extends UIComponent {
         vsyncCheck = new CheckBox("", skin);
         vsyncCheck.setChecked(settings.vsync);
 
-        Label uiScaleLabel = new Label("UI Scale (Unused):", skin);
-        uiScaleSlider = new Slider(0.2f, 2f, 0.1f, false, skin);
-        uiScaleSlider.setValue(settings.uiScale);
-        Label uiScaleValue = new Label(String.format("%.2fx", settings.uiScale), skin);
-
         Label musicVolumeLabel = new Label("Music Volume:", skin);
         musicVolumeSlider = new Slider(0f, 1f, 0.05f, false, skin);
         musicVolumeSlider.setValue(settings.musicVolume);
-        Label musicVolumeValue = new Label(String.format("%.0f%%", settings.musicVolume * 100), skin);
+        Label musicVolumeValue = new Label(String.format(PERCENT_FORMAT, settings.musicVolume * 100), skin);
 
         Label soundVolumeLabel = new Label("Sound Volume:", skin);
         soundVolumeSlider = new Slider(0f, 1f, 0.05f, false, skin);
         soundVolumeSlider.setValue(settings.soundVolume);
-        Label soundVolumeValue = new Label(String.format("%.0f%%", settings.soundVolume * 100), skin);
+        Label soundVolumeValue = new Label(String.format(PERCENT_FORMAT, settings.soundVolume * 100), skin);
 
 
         Label muteLabel = new Label("Mute:", skin);
@@ -118,10 +111,10 @@ public class SettingsMenuDisplay extends UIComponent {
         displayModeSelect.setSelected(getActiveMode(displayModeSelect.getItems()));
 
         Label actionLabel = new Label("Action: ", skin);
-        actionSelect = new SelectBox<>(skin);
+        SelectBox<String> actionSelect = new SelectBox<>(skin);
         actionSelect.setItems(actions);
         Label keyLabel = new Label("Key: ", skin);
-        keySelect = new SelectBox<>(skin);
+        SelectBox<String> keySelect = new SelectBox<>(skin);
         keySelect.setItems(keys);
 
         // Position Components on table
@@ -141,14 +134,6 @@ public class SettingsMenuDisplay extends UIComponent {
         table.row().padTop(10f);
         table.add(muteLabel).right().padRight(15f);
         table.add(muteCheck).left();
-
-        table.row().padTop(10f);
-        Table uiScaleTable = new Table();
-        uiScaleTable.add(uiScaleSlider).width(100).left();
-        uiScaleTable.add(uiScaleValue).left().padLeft(5f).expandX();
-
-        table.add(uiScaleLabel).right().padRight(15f);
-        table.add(uiScaleTable).left();
 
         table.row().padTop(10f);
         table.add(displayModeLabel).right().padRight(15f);
@@ -176,14 +161,6 @@ public class SettingsMenuDisplay extends UIComponent {
         table.add(keyLabel).right().padRight(15f);
         table.add(keySelect).left();
 
-
-        // Listener for uiScaleSlider
-        uiScaleSlider.addListener(
-                (Event event) -> {
-                    float value = uiScaleSlider.getValue();
-                    uiScaleValue.setText(String.format("%.2fx", value));
-                    return true;
-                });
         musicVolumeSlider.addListener(
                 (Event event) -> {
                     float value = musicVolumeSlider.getValue();
@@ -199,7 +176,6 @@ public class SettingsMenuDisplay extends UIComponent {
                 });
         return table;
     }
-
 
     private StringDecorator<DisplayMode> getActiveMode(Array<StringDecorator<DisplayMode>> modes) {
         DisplayMode active = Gdx.graphics.getDisplayMode();
@@ -263,7 +239,7 @@ public class SettingsMenuDisplay extends UIComponent {
         Dialog confirmationDialog = new Dialog("Confirm Changes", skin) {
             @Override
             protected void result(Object object) {
-                if ((Boolean) object) {
+                if (Boolean.TRUE.equals(object)) {
                     // If "Okay" is pressed, apply changes and go to the main menu
                     logger.debug("Confirmed changes");
                     UserSettings.Settings settings = UserSettings.get();
@@ -274,7 +250,6 @@ public class SettingsMenuDisplay extends UIComponent {
                     }
                     settings.fullscreen = fullScreenCheck.isChecked();
                     settings.mute = muteCheck.isChecked();
-                    settings.uiScale = uiScaleSlider.getValue();
                     settings.displayMode = new DisplaySettings(displayModeSelect.getSelected().object);
                     settings.vsync = vsyncCheck.isChecked();
                     settings.musicVolume = musicVolumeSlider.getValue();

--- a/source/core/src/main/com/csse3200/game/files/UserSettings.java
+++ b/source/core/src/main/com/csse3200/game/files/UserSettings.java
@@ -58,8 +58,6 @@ public class UserSettings {
         log.info("{}", settings.mute);
         log.info("{}", settings.musicVolume);
 
-        //applyAudioSettings(settings);
-
         if (settings.fullscreen) {
             DisplayMode displayMode = findMatching(settings.displayMode);
             if (displayMode == null) {
@@ -98,10 +96,6 @@ public class UserSettings {
         public boolean fullscreen = true;
         public boolean vsync = true;
         public boolean mute = false;
-        /**
-         * ui Scale. Currently unused, but can be implemented.
-         */
-        public float uiScale = 1f;
         public DisplaySettings displayMode = null;
         public float musicVolume = 0.3f;
         public float soundVolume = 0.5f;
@@ -114,7 +108,6 @@ public class UserSettings {
         public int width;
         public int height;
         public int refreshRate;
-        public int zoomScale;
 
         public DisplaySettings() {
         }

--- a/source/core/src/main/com/csse3200/game/options/GameOptions.java
+++ b/source/core/src/main/com/csse3200/game/options/GameOptions.java
@@ -1,5 +1,6 @@
 package com.csse3200.game.options;
 
+import com.csse3200.game.entities.Entity;
 import com.csse3200.game.entities.factories.PlayerFactory;
 
 /**
@@ -9,15 +10,44 @@ import com.csse3200.game.entities.factories.PlayerFactory;
 public class GameOptions {
 
     /** The difficulty of the game. */
-    public Difficulty difficulty;
+    private Difficulty difficulty;
     /**
-     * The path to the json file of the selected player.
+     * The player factory that will produce the in-game player chosen by the user.
      */
-    public PlayerFactory playerFactory;
+    private PlayerFactory playerFactory;
+
     /**
-     * Whether to load from save files when the game starts.
+     * Get player-set difficulty.
+     * @return difficulty chosen by player.
      */
-    public boolean shouldLoad;
+    public Difficulty getDifficulty() {
+        return difficulty;
+    }
+
+    /**
+     * Set the difficulty. Should only happen once per game
+     * @param difficulty difficulty chosen by player.
+     */
+    public void setDifficulty(Difficulty difficulty) {
+        this.difficulty = difficulty;
+    }
+
+    /**
+     * Set the player factory after the user chose a player.
+     * @param playerFactory player factory to use to make a player.
+     */
+    public void setPlayerFactory(PlayerFactory playerFactory) {
+        this.playerFactory = playerFactory;
+    }
+
+    /**
+     * Create a player as per the user's choice.
+     * @param difficulty difficulty to scale the player for.
+     * @return player entity.
+     */
+    public Entity createPlayer(Difficulty difficulty) {
+        return playerFactory.create(difficulty);
+    }
 
     /**
      * The difficulty of the game. Will likely affect map creation (number of rooms). May affect

--- a/source/core/src/main/com/csse3200/game/screens/LoadGameScreen.java
+++ b/source/core/src/main/com/csse3200/game/screens/LoadGameScreen.java
@@ -40,9 +40,9 @@ public class LoadGameScreen extends GameScreen {
         }
 
         PlayerFactoryFactory playerFactoryFactory = new PlayerFactoryFactory(List.of(config));
-        gameOptions.playerFactory = playerFactoryFactory.create(config.name);
+        gameOptions.setPlayerFactory(playerFactoryFactory.create(config.name));
         
-        Entity player = gameOptions.playerFactory.create(config.difficulty);
+        Entity player = gameOptions.createPlayer(config.difficulty);
         player.getEvents().addListener("player_finished_dying", this::loseGame);
 
         logger.debug("Initialising load game screen entities");

--- a/source/core/src/main/com/csse3200/game/screens/MainGameScreen.java
+++ b/source/core/src/main/com/csse3200/game/screens/MainGameScreen.java
@@ -25,16 +25,16 @@ public class MainGameScreen extends GameScreen {
         GameArea gameArea = new GameArea();
 
         GameOptions gameOptions = game.gameOptions;
-        logger.info("Starting game with difficulty {}", gameOptions.difficulty.toString());
+        logger.info("Starting game with difficulty {}", gameOptions.getDifficulty());
 
-        Entity player = gameOptions.playerFactory.create(gameOptions.difficulty);
+        Entity player = gameOptions.createPlayer(gameOptions.getDifficulty());
         player.getEvents().addListener("player_finished_dying", this::loseGame);
 
         logger.debug("Initialising main game screen entities");
         MapLoadConfig mapConfig = new MapLoadConfig();
         mapConfig.currentLevel = "0";
         LevelFactory levelFactory = new MainGameLevelFactory(false, mapConfig);
-        if (gameOptions.difficulty == TEST) {
+        if (gameOptions.getDifficulty() == TEST) {
             new TestGameArea(gameArea, levelFactory, player);
         } else {
             new GameController(gameArea, levelFactory, player, shouldLoad, mapConfig);

--- a/source/core/src/main/com/csse3200/game/screens/MainGameScreen.java
+++ b/source/core/src/main/com/csse3200/game/screens/MainGameScreen.java
@@ -4,22 +4,8 @@ import com.csse3200.game.GdxGame;
 import com.csse3200.game.areas.*;
 import com.csse3200.game.entities.Entity;
 import com.csse3200.game.entities.configs.MapLoadConfig;
-import com.csse3200.game.entities.configs.PlayerConfig;
-import com.csse3200.game.entities.factories.PlayerFactory;
-import com.csse3200.game.entities.factories.RenderFactory;
-import com.csse3200.game.files.FileLoader;
 import com.csse3200.game.options.GameOptions;
-import com.csse3200.game.services.*;
-import com.csse3200.game.ui.terminal.Terminal;
-import com.csse3200.game.ui.terminal.TerminalDisplay;
-import com.csse3200.game.options.GameOptions.Difficulty;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
-
-import static com.csse3200.game.GdxGame.ScreenType.LOSE;
-import static com.csse3200.game.areas.GameController.MAP_SAVE_PATH;
 import static com.csse3200.game.options.GameOptions.Difficulty.TEST;
 
 /**

--- a/source/core/src/test/com/csse3200/game/ui/terminal/KeyboardTerminalInputComponentTest.java
+++ b/source/core/src/test/com/csse3200/game/ui/terminal/KeyboardTerminalInputComponentTest.java
@@ -1,13 +1,12 @@
 package com.csse3200.game.ui.terminal;
 
 import com.badlogic.gdx.Input;
-import com.csse3200.game.components.player.KeyMapping;
-import com.csse3200.game.components.player.KeyboardPlayerInputComponent;
 import com.csse3200.game.extensions.GameExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(GameExtension.class)
@@ -29,16 +28,6 @@ class KeyboardTerminalInputComponentTest {
     verify(terminal).setOpen();
     verify(terminal, times(2)).setClosed();
   }
-
-  /*
-  @Test
-  void getItemTest() {
-    KeyboardPlayerInputComponent inputComponent = new KeyboardPlayerInputComponent();
-    KeyMapping.KeyBinding keyBinding = KeyMapping.KeyBinding.USE_1;
-    assertEquals(1, inputComponent.getItemNum(keyBinding));
-  }
-
-   */
 
   @Test
   void shouldUpdateMessageOnKeyTyped() {


### PR DESCRIPTION
# Description

Remove menu smells
- Comments
- Unused imports/methods/fields
- Make some public fields private

How to play screen scales better
- Uses word wrap
- Wrapping lines instead of paragraphs

No related issue

## Type of change

Please delete options that are not relevant.

- [x] Code smells

# How Has This Been Tested?

- [x] All unit tests still work
- [x] Applying/changing settings still works
- [x] Player selection and loading still works
- [x] How to play screen scales - try resizing the window, the text will wrap

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (no changes needed)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules