### PR TITLE
Fix minimap not showing correct rooms

### DIFF
--- a/source/core/src/main/com/csse3200/game/areas/generation/MapGenerator.java
+++ b/source/core/src/main/com/csse3200/game/areas/generation/MapGenerator.java
@@ -274,6 +274,10 @@ public class MapGenerator {
         String location = "0_0";
         int maxDist = 0;
         for (Map.Entry<String, List<String>> entry : relativePosition.entrySet()) {
+            if (Collections.frequency(entry.getValue(), "") != 3) {
+                // checking whether there is only 1 connection to room
+                continue;
+            }
             String key = entry.getKey();
             int dist = calculateDistance(key);
             if (maxDist < dist) {

--- a/source/core/src/main/com/csse3200/game/areas/generation/MapGenerator.java
+++ b/source/core/src/main/com/csse3200/game/areas/generation/MapGenerator.java
@@ -237,10 +237,11 @@ public class MapGenerator {
     private void setNpcRoom(List<String> setRooms) {
         List<String> rooms = new ArrayList<>(roomDetails.keySet());
         String randomRoomKey;
+        int connections;
         do {
             randomRoomKey = rooms.get(rng.getRandomInt(0, rooms.size()));
-        } while (setRooms.contains(randomRoomKey));
-
+            connections = Collections.frequency(relativePosition.get(randomRoomKey), "");
+        } while (setRooms.contains(randomRoomKey) ||  connections != 3);
         // Get the random room details
         HashMap<String, Integer> details = roomDetails.get(randomRoomKey);
         details.put("room_type", NPCROOM);
@@ -255,9 +256,11 @@ public class MapGenerator {
     private void setGameRoom(List<String> setRooms) {
         List<String> rooms = new ArrayList<>(roomDetails.keySet());
         String randomRoomKey;
+        int connections;
         do {
             randomRoomKey = rooms.get(rng.getRandomInt(0, rooms.size()));
-        } while (setRooms.contains(randomRoomKey));
+            connections = Collections.frequency(relativePosition.get(randomRoomKey), "");
+        } while (setRooms.contains(randomRoomKey) ||  connections != 3);
 
         // Get the random room details
         HashMap<String, Integer> details = roomDetails.get(randomRoomKey);

--- a/source/core/src/main/com/csse3200/game/areas/minimap/MinimapFactory.java
+++ b/source/core/src/main/com/csse3200/game/areas/minimap/MinimapFactory.java
@@ -10,12 +10,8 @@ import com.badlogic.gdx.maps.tiled.TiledMapTileLayer;
 import com.badlogic.gdx.maps.tiled.renderers.OrthogonalTiledMapRenderer;
 import com.badlogic.gdx.math.GridPoint2;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
-import com.csse3200.game.areas.Level;
-import com.csse3200.game.areas.Room;
+import com.csse3200.game.areas.*;
 import com.csse3200.game.services.ServiceLocator;
-
-import com.csse3200.game.areas.BossRoom;
-import com.csse3200.game.areas.GambleRoom;
 
 import java.util.List;
 
@@ -146,6 +142,8 @@ public class MinimapFactory {
                         connectionCode += "_boss";
                     } else if (tempRoom instanceof GambleRoom) {
                         connectionCode += "_gambling";
+                    } else if (tempRoom instanceof ShopRoom) {
+                        connectionCode += "_npc";
                     }
 
                     // Assign the correct tile based on the connection code


### PR DESCRIPTION
# Description
The minimap was working off extra rooms (boss, npc, gambling) only have 1 connection. Fixed this so that they generate with only with one connection for each

Fixes / Closes #476 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Testing was visual testing with different seeds to confirm that when the rooms were generated with different connection locations (One on the North, South, East or West side) that it was still working

# Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ x] Any dependent changes have been merged and published in downstream modules
