### PR TITLE
Remove Gamble Room and Refactor 'NPC' to 'Shop' in all instances

### DIFF
--- a/source/core/assets/skins/minimap/minimap.atlas
+++ b/source/core/assets/skins/minimap/minimap.atlas
@@ -25,14 +25,7 @@ repeat: none
   orig: 140, 140
   offset: 0, 0
   index: -1
-0001_gambling
-  rotate: false
-  xy: 1, 569
-  size: 140, 140
-  orig: 140, 140
-  offset: 0, 0
-  index: -1
-0001_npc
+0001_shop
   rotate: false
   xy: 143, 711
   size: 140, 140
@@ -53,14 +46,7 @@ repeat: none
   orig: 140, 140
   offset: 0, 0
   index: -1
-0010_gambling
-  rotate: false
-  xy: 143, 569
-  size: 140, 140
-  orig: 140, 140
-  offset: 0, 0
-  index: -1
-0010_npc
+0010_shop
   rotate: false
   xy: 285, 711
   size: 140, 140
@@ -88,14 +74,7 @@ repeat: none
   orig: 140, 140
   offset: 0, 0
   index: -1
-0100_gambling
-  rotate: false
-  xy: 285, 569
-  size: 140, 140
-  orig: 140, 140
-  offset: 0, 0
-  index: -1
-0100_npc
+0100_shop
   rotate: false
   xy: 427, 711
   size: 140, 140
@@ -137,14 +116,7 @@ repeat: none
   orig: 140, 140
   offset: 0, 0
   index: -1
-1000_gambling
-  rotate: false
-  xy: 569, 711
-  size: 140, 140
-  orig: 140, 140
-  offset: 0, 0
-  index: -1
-1000_npc
+1000_shop
   rotate: false
   xy: 711, 853
   size: 140, 140

--- a/source/core/src/main/com/csse3200/game/areas/GameController.java
+++ b/source/core/src/main/com/csse3200/game/areas/GameController.java
@@ -145,7 +145,7 @@ public class GameController {
      * @throws IllegalArgumentException if an invalid room type is provided.
      */
     public String getFlaggedRoom(String roomType) {
-        if (!List.of("Boss", "NPC", "GameRoom").contains(roomType)) {
+        if (!List.of("Boss", "Shop").contains(roomType)) {
             throw new IllegalArgumentException("Invalid room type: " + roomType);
         }
         return currentLevel.getMap().mapData.getRoomKey(roomType);

--- a/source/core/src/main/com/csse3200/game/areas/GameController.java
+++ b/source/core/src/main/com/csse3200/game/areas/GameController.java
@@ -92,7 +92,7 @@ public class GameController {
         this.shouldLoad = shouldLoad;
         this.gameArea = gameArea;
         player.getEvents().addListener("teleportToBoss", () -> this.changeRooms(getFlaggedRoom("Boss")));
-        player.getEvents().addListener("teleportToShop", () -> this.changeRooms(getFlaggedRoom("NPC")));
+        player.getEvents().addListener("teleportToShop", () -> this.changeRooms(getFlaggedRoom("Shop")));
         player.getEvents().addListener("saveMapData", this::saveMapData);
         player.getEvents().addListener("checkAnimalsDead", () -> this.getCurrentRoom().checkComplete());
         ServiceLocator.registerGameAreaService(new GameAreaService(this));

--- a/source/core/src/main/com/csse3200/game/areas/GameController.java
+++ b/source/core/src/main/com/csse3200/game/areas/GameController.java
@@ -140,7 +140,7 @@ public class GameController {
     /**
      * Get the room key for a specified flagged room type.
      *
-     * @param roomType The type of room to get the key for. Valid values are "Boss", "NPC", and "GameRoom".
+     * @param roomType The type of room to get the key for. Valid values are "Boss" and "Shop".
      * @return The room key for the specified room type, or null if the room type is invalid.
      * @throws IllegalArgumentException if an invalid room type is provided.
      */

--- a/source/core/src/main/com/csse3200/game/areas/MainGameLevelFactory.java
+++ b/source/core/src/main/com/csse3200/game/areas/MainGameLevelFactory.java
@@ -159,7 +159,7 @@ public class MainGameLevelFactory implements LevelFactory {
                 }
             }
         }
-        ShopRoom shopRoom = (ShopRoom)rooms.get(ServiceLocator.getGameAreaService().getGameController().getFlaggedRoom("NPC"));
+        ShopRoom shopRoom = (ShopRoom)rooms.get(ServiceLocator.getGameAreaService().getGameController().getFlaggedRoom("Shop"));
         List<String> shopSave = shopRoom.itemsSpawned;
         config.shopRoomItems.addAll(shopSave);
         config.roomsCompleted = compRooms;

--- a/source/core/src/main/com/csse3200/game/areas/MainGameLevelFactory.java
+++ b/source/core/src/main/com/csse3200/game/areas/MainGameLevelFactory.java
@@ -101,7 +101,7 @@ public class MainGameLevelFactory implements LevelFactory {
                             map.mapData.getPositions().get(roomKey),
                             "0,0,14,10," + levelNumber + "," + levelNumber, roomKey));
                     break;
-                case MapGenerator.NPCROOM:
+                case MapGenerator.SHOPROOM:
                     //If the game is loaded the items to be spawned is loaded from the config
                     //if not uses the createShopItems method to create a random list which is then loaded into the shop
                     // room to be spawned.
@@ -115,11 +115,6 @@ public class MainGameLevelFactory implements LevelFactory {
                             map.mapData.getPositions().get(roomKey),
                             "0,0,14,10," + 0 + "," + levelNumber, roomKey, itemsToBeSpawned);
                     rooms.put(roomKey, shop);
-                    break;
-                case MapGenerator.GAMEROOM:
-                    rooms.put(roomKey, roomFactory.createGambleRoom(
-                            map.mapData.getPositions().get(roomKey),
-                            "0,0,14,10," + levelNumber + "," + levelNumber, roomKey));
                     break;
                 default:
                     rooms.put(roomKey, roomFactory.createRoom(

--- a/source/core/src/main/com/csse3200/game/areas/generation/MapGenerator.java
+++ b/source/core/src/main/com/csse3200/game/areas/generation/MapGenerator.java
@@ -12,8 +12,7 @@ public class MapGenerator {
     private Map<String, String> RoomKeys = new HashMap<String, String>();
     public static final int BASEROOM = 0;
     public static final int BOSSROOM = 1;
-    public static final int NPCROOM = 2;
-    public static final int GAMEROOM = 3;
+    public static final int SHOPROOM = 2;
 
 
     public int mapSize;
@@ -215,7 +214,6 @@ public class MapGenerator {
 
         setBossRoom(setRooms);
         setNpcRoom(setRooms);
-        setGameRoom(setRooms);
     }
 
     /**
@@ -244,28 +242,8 @@ public class MapGenerator {
         } while (setRooms.contains(randomRoomKey) ||  connections != 3);
         // Get the random room details
         HashMap<String, Integer> details = roomDetails.get(randomRoomKey);
-        details.put("room_type", NPCROOM);
+        details.put("room_type", SHOPROOM);
         RoomKeys.put("NPC", randomRoomKey);
-        setRooms.add(randomRoomKey);
-    }
-
-    /**
-     * Set Game Room
-     * @param setRooms - rooms already set with specific types
-     */
-    private void setGameRoom(List<String> setRooms) {
-        List<String> rooms = new ArrayList<>(roomDetails.keySet());
-        String randomRoomKey;
-        int connections;
-        do {
-            randomRoomKey = rooms.get(rng.getRandomInt(0, rooms.size()));
-            connections = Collections.frequency(relativePosition.get(randomRoomKey), "");
-        } while (setRooms.contains(randomRoomKey) ||  connections != 3);
-
-        // Get the random room details
-        HashMap<String, Integer> details = roomDetails.get(randomRoomKey);
-        details.put("room_type", GAMEROOM);
-        RoomKeys.put("GameRoom", randomRoomKey);
         setRooms.add(randomRoomKey);
     }
 

--- a/source/core/src/main/com/csse3200/game/areas/generation/MapGenerator.java
+++ b/source/core/src/main/com/csse3200/game/areas/generation/MapGenerator.java
@@ -229,7 +229,7 @@ public class MapGenerator {
     }
 
     /**
-     * Set NPC room
+     * Set Shop Room
      * @param setRooms - rooms already set with specific types
      */
     private void setShopRoom(List<String> setRooms) {

--- a/source/core/src/main/com/csse3200/game/areas/generation/MapGenerator.java
+++ b/source/core/src/main/com/csse3200/game/areas/generation/MapGenerator.java
@@ -243,7 +243,7 @@ public class MapGenerator {
         // Get the random room details
         HashMap<String, Integer> details = roomDetails.get(randomRoomKey);
         details.put("room_type", SHOPROOM);
-        RoomKeys.put("NPC", randomRoomKey);
+        RoomKeys.put("Shop", randomRoomKey);
         setRooms.add(randomRoomKey);
     }
 

--- a/source/core/src/main/com/csse3200/game/areas/generation/MapGenerator.java
+++ b/source/core/src/main/com/csse3200/game/areas/generation/MapGenerator.java
@@ -213,7 +213,7 @@ public class MapGenerator {
         setRooms.add("0_0");
 
         setBossRoom(setRooms);
-        setNpcRoom(setRooms);
+        setShopRoom(setRooms);
     }
 
     /**
@@ -232,7 +232,7 @@ public class MapGenerator {
      * Set NPC room
      * @param setRooms - rooms already set with specific types
      */
-    private void setNpcRoom(List<String> setRooms) {
+    private void setShopRoom(List<String> setRooms) {
         List<String> rooms = new ArrayList<>(roomDetails.keySet());
         String randomRoomKey;
         int connections;

--- a/source/core/src/main/com/csse3200/game/areas/minimap/MinimapFactory.java
+++ b/source/core/src/main/com/csse3200/game/areas/minimap/MinimapFactory.java
@@ -64,18 +64,14 @@ public class MinimapFactory {
                 minimapSkin.getRegion("0001"),
                 minimapSkin.getRegion("1011"),
                 minimapSkin.getRegion("0000"),
-                minimapSkin.getRegion("1000_gambling"),
-                minimapSkin.getRegion("0100_gambling"),
-                minimapSkin.getRegion("0010_gambling"),
-                minimapSkin.getRegion("0001_gambling"),
                 minimapSkin.getRegion("1000_boss"),
                 minimapSkin.getRegion("0100_boss"),
                 minimapSkin.getRegion("0010_boss"),
                 minimapSkin.getRegion("0001_boss"),
-                minimapSkin.getRegion("1000_npc"),
-                minimapSkin.getRegion("0100_npc"),
-                minimapSkin.getRegion("0010_npc"),
-                minimapSkin.getRegion("0001_npc")
+                minimapSkin.getRegion("1000_shop"),
+                minimapSkin.getRegion("0100_shop"),
+                minimapSkin.getRegion("0010_shop"),
+                minimapSkin.getRegion("0001_shop")
         };
     }
 
@@ -140,10 +136,8 @@ public class MinimapFactory {
 
                     if (tempRoom instanceof BossRoom) {
                         connectionCode += "_boss";
-                    } else if (tempRoom instanceof GambleRoom) {
-                        connectionCode += "_gambling";
                     } else if (tempRoom instanceof ShopRoom) {
-                        connectionCode += "_npc";
+                        connectionCode += "_shop";
                     }
 
                     // Assign the correct tile based on the connection code
@@ -261,30 +255,22 @@ public class MinimapFactory {
                 return 13;
             case "1011":
                 return 14;
-            case "1000_gambling":
-                return 16;
-            case "0100_gambling":
-                return 17;
-            case "0010_gambling":
-                return 18;
-            case "0001_gambling":
-                return 19;
             case "1000_boss":
-                return 20;
+                return 16;
             case "0100_boss":
-                return 21;
+                return 17;
             case "0010_boss":
-                return 22;
+                return 18;
             case "0001_boss":
+                return 19;
+            case "1000_shop":
+                return 20;
+            case "0100_shop":
+                return 21;
+            case "0010_shop":
+                return 22;
+            case "0001_shop":
                 return 23;
-            case "1000_npc":
-                return 24;
-            case "0100_npc":
-                return 25;
-            case "0010_npc":
-                return 26;
-            case "0001_npc":
-                return 27;
             default:
                 return 15; // 0000 (no connections)
         }

--- a/source/core/src/main/com/csse3200/game/entities/factories/RoomFactory.java
+++ b/source/core/src/main/com/csse3200/game/entities/factories/RoomFactory.java
@@ -61,14 +61,4 @@ public class RoomFactory {
         return new ShopRoom(this.npcFactory, this.collectibleFactory,
                             this.terrainFactory, roomConnections, specification, roomName, shopItemList);
     }
-
-
-    public Room createGambleRoom(List<String> roomConnections, String specification, String roomName) {
-        // add connections to boss Room
-        return new GambleRoom( this.collectibleFactory,
-                            this.terrainFactory, roomConnections, specification, roomName);
-    }
-
-
-
 }

--- a/source/core/src/test/com/csse3200/game/areas/MapGenerationTest.java
+++ b/source/core/src/test/com/csse3200/game/areas/MapGenerationTest.java
@@ -157,9 +157,7 @@ class MapGeneratorTest {
         }
         assertEquals(Collections.frequency(types, MapGenerator.BOSSROOM), 1,
                 "Should have only one boss room");
-        assertEquals(Collections.frequency(types, MapGenerator.NPCROOM), 1,
+        assertEquals(Collections.frequency(types, MapGenerator.SHOPROOM), 1,
                 "Should have only one NPC room");
-        assertEquals(Collections.frequency(types, MapGenerator.GAMEROOM), 1,
-                "Should have only one Game room");
     }
 }

--- a/source/core/src/test/com/csse3200/game/areas/Rooms/RoomFactoryTest.java
+++ b/source/core/src/test/com/csse3200/game/areas/Rooms/RoomFactoryTest.java
@@ -74,15 +74,6 @@ class RoomFactoryTest {
     }
 
     @Test
-    void testCreateGambleRoom() {
-        Room room = roomFactory.createGambleRoom(testRoomConnections, testSpecification, testRoomName);
-        
-        assertNotNull(room);
-        assertTrue(room instanceof GambleRoom);
-        assertEquals(testRoomName, room.getRoomName());
-    }
-
-    @Test
     void testRoomInterfaceMethods() {
         Room room = roomFactory.createRoom(testRoomConnections, testSpecification, testRoomName);
         


### PR DESCRIPTION
# Description

Removed the gamble room and any relating content to it
Refactored 'NPC' to 'Shop' for the `ShopRoom` as there were different naming conventions used for the room during development

Fixes / Closes #501 

## Type of change
- [x] This change requires a documentation update

# How Has This Been Tested?

The normal unit tests, and running of the game traversing to both `ShopRoom` and `BossRoom` through the normal game structure and keybinding jumps to confirm still working correctly. 2 different seeds were tested as well to confirm this wasn't just due to current seed dynamic.
Minimap was changed as well with its references to gambling room and npc room. This was tested with unit tests and visually in the game when testing the rooms (including with different seeds to check different room positions still worked)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
