### PR TITLE
Balance game with changable bullet speed during boss phase

### DIFF
--- a/source/core/assets/configs/projectiles.json
+++ b/source/core/assets/configs/projectiles.json
@@ -20,8 +20,8 @@
     "baseAttack": 10,
     "isDirectional": true,
     "speed": {
-      "x": 3,
-      "y": 3
+      "x": 7,
+      "y": 7
     },
     "Layer": 2,
     "scaleX": 1.2,

--- a/source/core/src/main/com/csse3200/game/components/npc/attack/BossRangeAttackComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/npc/attack/BossRangeAttackComponent.java
@@ -5,6 +5,7 @@ import com.badlogic.gdx.math.Vector2;
 import java.util.Random;
 
 import com.csse3200.game.components.NameComponent;
+import com.csse3200.game.components.projectile.ProjectileAttackComponent;
 import com.csse3200.game.entities.Entity;
 import com.csse3200.game.entities.configs.AttackConfig;
 import com.csse3200.game.entities.factories.ProjectileFactory;
@@ -21,6 +22,7 @@ public class BossRangeAttackComponent extends RangeAttackComponent {
     private Vector2[] spawnLocations;
     private Vector2[] movingDirections;
     private final Random rand = new Random();
+
 
     private final ProjectileFactory projectileFactory = new ProjectileFactory();
 
@@ -41,6 +43,8 @@ public class BossRangeAttackComponent extends RangeAttackComponent {
     public void setMovingDirections(Vector2[] movingDirections) {
         this.movingDirections = movingDirections;
     }
+
+
 
     /**
      * Set shoot patterns for each projectile (each projectile must have location and direction)
@@ -100,6 +104,9 @@ public class BossRangeAttackComponent extends RangeAttackComponent {
 
     private void singleShoot(Vector2 spawnLocation, Vector2 movingDirection) {
         Entity projectile = projectileFactory.create(getProjectileNames()[getAnimationID()], movingDirection, spawnLocation);
+        ProjectileAttackComponent projectileAttackComponent = projectile.getComponent(ProjectileAttackComponent.class);
+        Vector2 v = projectileAttackComponent.getSpeed();
+        projectileAttackComponent.setSpeed(new Vector2(v.x * speedCoefficient, v.y * speedCoefficient));
         projectile.getComponent(com.csse3200.game.components.projectile.ProjectileAttackComponent.class).create();
         ServiceLocator.getGameAreaService().getGameArea().spawnEntityAt(projectile, new GridPoint2(9,9),
                 true, true);

--- a/source/core/src/main/com/csse3200/game/components/npc/attack/RangeAttackComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/npc/attack/RangeAttackComponent.java
@@ -4,6 +4,7 @@ import com.badlogic.gdx.math.GridPoint2;
 import com.badlogic.gdx.math.Vector2;
 import com.csse3200.game.components.NameComponent;
 import com.csse3200.game.components.npc.DirectionalNPCComponent;
+import com.csse3200.game.components.projectile.ProjectileAttackComponent;
 import com.csse3200.game.entities.Entity;
 import com.csse3200.game.entities.configs.AttackConfig;
 import com.csse3200.game.entities.factories.ProjectileFactory;
@@ -19,6 +20,7 @@ public class RangeAttackComponent extends AttackComponent {
     private String[] projectileNames;
     private String[] attackTriggers;
     private int animationID = 0;
+    float speedCoefficient = 1.0f;
 
     private final ProjectileFactory projectileFactory = new ProjectileFactory();
 
@@ -49,6 +51,10 @@ public class RangeAttackComponent extends AttackComponent {
 
     protected int getAnimationID() {
         return animationID;
+    }
+
+     public void setSpeedCoefficient(float f) {
+        speedCoefficient = f;
     }
 
     /**
@@ -197,6 +203,9 @@ public class RangeAttackComponent extends AttackComponent {
      */
     private void singleShoot(Vector2 direction) {
         Entity projectile = projectileFactory.create(getProjectileNames()[getAnimationID()], direction, entity.getPosition());
+        ProjectileAttackComponent projectileAttackComponent = projectile.getComponent(ProjectileAttackComponent.class);
+        Vector2 v = projectileAttackComponent.getSpeed();
+        projectileAttackComponent.setSpeed(new Vector2(v.x * speedCoefficient, v.y * speedCoefficient));
         projectile.getComponent(com.csse3200.game.components.projectile.ProjectileAttackComponent.class).create();
         ServiceLocator.getGameAreaService().getGameArea().spawnEntityAt(projectile, new GridPoint2(9, 9),
                 true, true);

--- a/source/core/src/main/com/csse3200/game/components/projectile/ProjectileAttackComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/projectile/ProjectileAttackComponent.java
@@ -28,7 +28,7 @@ public class ProjectileAttackComponent extends Component {
     private final short targetLayer;
     private CombatStatsComponent combatStats;
     private HitboxComponent hitboxComponent;
-    private final Vector2 speed;
+    private Vector2 speed;
     private final Vector2 direction;
     private final Vector2 parentPosition;
     private final float range;
@@ -45,6 +45,14 @@ public class ProjectileAttackComponent extends Component {
         this.direction = direction;
         this.parentPosition = parentPosition;
         this.range = range;
+    }
+
+    public void setSpeed(Vector2 v) {
+        speed = v;
+    }
+
+    public Vector2 getSpeed() {
+        return speed;
     }
 
     /**

--- a/source/core/src/main/com/csse3200/game/components/tasks/BulletStormTask.java
+++ b/source/core/src/main/com/csse3200/game/components/tasks/BulletStormTask.java
@@ -6,6 +6,7 @@ import com.csse3200.game.ai.tasks.PriorityTask;
 import com.csse3200.game.ai.tasks.Task;
 import com.csse3200.game.components.CombatStatsComponent;
 import com.csse3200.game.components.npc.attack.BossRangeAttackComponent;
+import com.csse3200.game.components.npc.attack.RangeAttackComponent;
 import com.csse3200.game.entities.configs.TaskConfig;
 import com.csse3200.game.services.GameTime;
 import com.csse3200.game.services.ServiceLocator;
@@ -66,12 +67,16 @@ public class BulletStormTask extends DefaultTask implements PriorityTask {
         logger.debug("Boss is moving to the center of the room at {}", centerPosition);
 
         // Enable the BossRangeAttackComponent
-        BossRangeAttackComponent rangeAttack = owner.getEntity().getComponent(BossRangeAttackComponent.class);
+        BossRangeAttackComponent bossRangeAttack = owner.getEntity().getComponent(BossRangeAttackComponent.class);
+        RangeAttackComponent rangeAttack = owner.getEntity().getComponent(RangeAttackComponent.class);
         int numShot = 4;
-        if (rangeAttack != null) {
-            setShootPattern(rangeAttack, numShot);
-
-            rangeAttack.setEnabled(true);
+        if (bossRangeAttack != null) {
+            setShootPattern(bossRangeAttack, numShot);
+            bossRangeAttack.setSpeedCoefficient(0.4f);
+            if (rangeAttack != null) {
+                rangeAttack.setSpeedCoefficient(0.4f);
+            }
+            bossRangeAttack.setEnabled(true);
             logger.debug("BossRangeAttackComponent enabled.");
         } else {
             logger.warn("BossRangeAttackComponent not found on the boss entity.");
@@ -120,9 +125,15 @@ public class BulletStormTask extends DefaultTask implements PriorityTask {
         logger.debug("Stopping BulletStormTask.");
 
         // Disable the BossRangeAttackComponent
-        BossRangeAttackComponent rangeAttack = owner.getEntity().getComponent(BossRangeAttackComponent.class);
-        if (rangeAttack != null) {
-            rangeAttack.setEnabled(false);
+        BossRangeAttackComponent bossRangeAttack = owner.getEntity().getComponent(BossRangeAttackComponent.class);
+        if (bossRangeAttack != null) {
+            bossRangeAttack.setEnabled(false);
+            // Convert the attack speed back to normal
+            RangeAttackComponent rangeAttack = owner.getEntity().getComponent(RangeAttackComponent.class);
+            if (rangeAttack != null) {
+                rangeAttack.setSpeedCoefficient(1f);
+            }
+
             logger.debug("BossRangeAttackComponent disabled.");
         }
 


### PR DESCRIPTION
# Description

Add a new bullet speed coefficient to `RangeAttackComponent` and change it during `BulletStormTask` duration. The bullet speed is changed within `RangeAttackComponent` and `BossRangeAttackComponent`.

Change the projectiles.json for corresponding change in new speed coefficient.

Fixes #530

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Test manually with the change of projectile speed during boss phase.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
