### PR TITLE
Fixing Labels and weapon Initialisation

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/player/PlayerAnimationController.java
+++ b/source/core/src/main/com/csse3200/game/components/player/PlayerAnimationController.java
@@ -18,7 +18,7 @@ public class PlayerAnimationController extends Component {
     /**
      Indicate the selected player.
      */
-    enum PlayerNum {
+    public enum PlayerNum {
         PLAYER_1,
         PLAYER_2,
         PLAYER_3,

--- a/source/core/src/main/com/csse3200/game/components/player/PlayerAnimationController.java
+++ b/source/core/src/main/com/csse3200/game/components/player/PlayerAnimationController.java
@@ -18,7 +18,7 @@ public class PlayerAnimationController extends Component {
     /**
      Indicate the selected player.
      */
-    private enum PlayerNum {
+    enum PlayerNum {
         PLAYER_1,
         PLAYER_2,
         PLAYER_3,
@@ -232,5 +232,12 @@ public class PlayerAnimationController extends Component {
 
             animationController.startAnimation(animationName);
         }
+    }
+    /**
+     * Returns the currently selected player number.
+     * @return The selected player number (e.g. PLAYER_1, PLAYER_2, etc.)
+     */
+    public PlayerNum getPlayerNum() {
+        return playerNum;
     }
 }

--- a/source/core/src/main/com/csse3200/game/components/player/PlayerStatsDisplay.java
+++ b/source/core/src/main/com/csse3200/game/components/player/PlayerStatsDisplay.java
@@ -56,7 +56,7 @@ public class PlayerStatsDisplay extends UIComponent {
         entity.getEvents().addListener("updateHealth", this::updatePlayerHealthUI);
         entity.getEvents().addListener("melee_pickup", this::updateMeleeWeaponUI);
         entity.getEvents().addListener("ranged_pickup", (Integer maxAmmo) -> {
-            updateGunLabel(20, "Gun");
+            updateGunLabel(6, "Gun");
             updateRangedWeaponUI(maxAmmo, "Gun");
         });
         entity.getEvents().addListener("ranged_activate", this::updateAmmoDisplay);
@@ -79,20 +79,25 @@ public class PlayerStatsDisplay extends UIComponent {
         // Get the current player number
         PlayerAnimationController.PlayerNum playerNum = playerController.getPlayerNum();
 
-        // Based on the selected player, display appropriate weapon and ammo counts
-        if (playerNum == PlayerAnimationController.PlayerNum.PLAYER_4 ||
-                playerNum == PlayerAnimationController.PlayerNum.PLAYER_2 ||
-                playerNum == PlayerAnimationController.PlayerNum.PLAYER_3 ||
-                playerNum == PlayerAnimationController.PlayerNum.BEAR) {
-            // Players 2, 3, 4, and Bear have 7 ammo with the gun
-            updateGunLabel(7, "Gun");
-            updateRangedWeaponUI(7, "Gun");
+        if (playerNum == PlayerAnimationController.PlayerNum.PLAYER_1) {
+            // Player 1 always starts with 20 ammo
+            updateGunLabel(6, "Gun");
+            updateRangedWeaponUI(6, "Gun");
         } else {
-            // For other players, set the gun to have 20 ammo
-            updateGunLabel(20, "Gun");
-            updateRangedWeaponUI(20, "Gun");
+            // Other players start with 7 ammo
+            updateGunLabel(15, "Gun");
+            updateRangedWeaponUI(15, "Gun");
+
+            // Set an event listener to update ammo to 20 when a ranged weapon is picked up
+            entity.getEvents().addListener("ranged_pickup", (Integer maxAmmo) -> {
+                if (maxAmmo == 6) {
+                    updateGunLabel(6, "Gun");
+                    updateRangedWeaponUI(6, "Gun");
+                }
+            });
         }
     }
+
 
     /**
      * Creates actors and positions them on the stage using a table.

--- a/source/core/src/main/com/csse3200/game/components/player/PlayerStatsDisplay.java
+++ b/source/core/src/main/com/csse3200/game/components/player/PlayerStatsDisplay.java
@@ -3,7 +3,6 @@ package com.csse3200.game.components.player;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
-import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.scenes.scene2d.ui.Image;
 import com.badlogic.gdx.scenes.scene2d.ui.Label;
 import com.badlogic.gdx.scenes.scene2d.ui.ProgressBar;
@@ -16,16 +15,15 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * A ui component for displaying player stats, e.g. health.
+ * A UI component for displaying player stats, e.g., health, weapon, ammo.
  */
 public class PlayerStatsDisplay extends UIComponent {
     Table table;
     Table ammoTable;
     private Image heartImage;
     private Label healthLabel;
-    private Label pickaxeLabel;
-    private Label shotgunLabel;
-
+    private Label meleeLabel;   // Updated label for melee weapon
+    private Label gunLabel;     // Updated label for gun
     private Texture ammoTexture;
     private List<Image> ammoImages;
     private int currentAmmo;
@@ -33,14 +31,13 @@ public class PlayerStatsDisplay extends UIComponent {
     float screenWidth = Gdx.graphics.getWidth();
 
     private Image speedImage;
-    private Label speedLabelText;
-
     private ProgressBar speedProgressBar;
 
     private Image damageImage;
     private ProgressBar damageProgressBar;
     private Image armorImage;
     private ProgressBar armorProgressBar;
+
     private ArrayList<Label> labels;
     public static final String HEART_TEXTURE = "images/heart.png";
     public static final String SPEED_TEXTURE = "images/items/energy_drink.png";
@@ -48,7 +45,7 @@ public class PlayerStatsDisplay extends UIComponent {
     public static final String ARMOR_TEXTURE = "images/items/armor.png";
 
     /**
-     * Creates reusable ui styles and adds actors to the stage.
+     * Creates reusable UI styles and adds actors to the stage.
      */
     @Override
     public void create() {
@@ -58,12 +55,43 @@ public class PlayerStatsDisplay extends UIComponent {
 
         entity.getEvents().addListener("updateHealth", this::updatePlayerHealthUI);
         entity.getEvents().addListener("melee_pickup", this::updateMeleeWeaponUI);
-        entity.getEvents().addListener("ranged_pickup", this::updateRangedWeaponUI);
+        entity.getEvents().addListener("ranged_pickup", (Integer maxAmmo) -> {
+            updateGunLabel(20, "Gun");
+            updateRangedWeaponUI(maxAmmo, "Gun");
+        });
         entity.getEvents().addListener("ranged_activate", this::updateAmmoDisplay);
         entity.getEvents().addListener("updateSpeedPercentage", this::updateSpeedPercentageUI);
         entity.getEvents().addListener("updateDamageBuff", this::updateDamageUI);
         entity.getEvents().addListener("updateSpeedUI", this::updateSpeedPercentageUI);
         entity.getEvents().addListener("updateArmor", this::updateArmorUI);
+
+        initializeWeaponsAndAmmo();
+    }
+
+    /**
+     * Initializes the weapon and ammo counts based on the player selected.
+     * Retrieves the player type from PlayerAnimationController.
+     */
+    private void initializeWeaponsAndAmmo() {
+        // Retrieve the PlayerAnimationController component from the entity
+        PlayerAnimationController playerController = entity.getComponent(PlayerAnimationController.class);
+
+        // Get the current player number
+        PlayerAnimationController.PlayerNum playerNum = playerController.getPlayerNum();
+
+        // Based on the selected player, display appropriate weapon and ammo counts
+        if (playerNum == PlayerAnimationController.PlayerNum.PLAYER_4 ||
+                playerNum == PlayerAnimationController.PlayerNum.PLAYER_2 ||
+                playerNum == PlayerAnimationController.PlayerNum.PLAYER_3 ||
+                playerNum == PlayerAnimationController.PlayerNum.BEAR) {
+            // Players 2, 3, 4, and Bear have 7 ammo with the gun
+            updateGunLabel(7, "Gun");
+            updateRangedWeaponUI(7, "Gun");
+        } else {
+            // For other players, set the gun to have 20 ammo
+            updateGunLabel(20, "Gun");
+            updateRangedWeaponUI(20, "Gun");
+        }
     }
 
     /**
@@ -72,7 +100,7 @@ public class PlayerStatsDisplay extends UIComponent {
      * @see Table for positioning options
      */
     private void addActors() {
-        labels = new ArrayList<Label>();
+        labels = new ArrayList<>();
 
         table = new Table();
         ammoTable = new Table();
@@ -96,59 +124,41 @@ public class PlayerStatsDisplay extends UIComponent {
         CharSequence healthText = String.format("Health: %d", health);
         healthLabel = new Label(healthText, skin, "small");
 
-        //Speed image
+        // Speed image
         float speedSideLength = 100f;
         speedImage = new Image(ServiceLocator.getResourceService().getAsset(SPEED_TEXTURE, Texture.class));
 
-        //Speed text
-        speedProgressBar = new ProgressBar(0f, 0.5f, 0.1f, false, skin);
-        Vector2 currSpeed = entity.getComponent(PlayerActions.class).getCurrPlayerSpeed();
-        Vector2 baseSpeed = entity.getComponent(PlayerActions.class).getBaseSpeed();
-        float newSpeedPercentage = entity.getComponent(PlayerActions.class).getSpeedProgressBarProportion(currSpeed, baseSpeed);
+        // Speed progress bar
+        speedProgressBar = new ProgressBar(0f, 1.5f, 0.1f, false, skin);
         speedProgressBar.setWidth(200f);
         speedProgressBar.setAnimateDuration(2.0f);
-        speedProgressBar.setValue(newSpeedPercentage);
-        /*
-        //Temporarily commented out in case design team prefers text instead of progress bar
-        float speedPercentage = entity.getComponent(PlayerActions.class).getTotalSpeedBoost();
-        CharSequence speedText = String.format("Speed: %.1f%%", speedPercentage);
-        speedLabelText = new Label(speedText, skin, "small");
-         */
 
-        //Damage Progress bar
-        //Will need to check values
+        // Damage progress bar
         float damageSideLength = 50f;
-//        damageImage = new Image(
-//                ServiceLocator.getResourceService().getAsset("images/heart.png", Texture.class));
         damageImage = new Image(ServiceLocator.getResourceService().getAsset(DAMAGE_BUFF_TEXTURE, Texture.class));
         damageProgressBar = new ProgressBar(0f, 200f, 0.1f, false, skin);
         damageProgressBar.setWidth(200f);
         damageProgressBar.setAnimateDuration(2.0f);
 
-        //Weapon text, like the name of weapon
-        //entity.getComponent(WeaponComponent.class).getWeaponType();
-        pickaxeLabel = new Label("Pickaxe: 0", skin, "small");
-        shotgunLabel = new Label("Shotgun: 0", skin, "small");
-
         // Armor image and progress bar
         float armorSideLength = 50f;
         armorImage = new Image(ServiceLocator.getResourceService().getAsset(ARMOR_TEXTURE, Texture.class));
-
-        // Armor progress bar (update the max armor as per the player's max armor value)
         armorProgressBar = new ProgressBar(0f, 100f, 1f, false, skin);
         armorProgressBar.setWidth(200f);
         armorProgressBar.setAnimateDuration(2.0f);
+
+        // Weapon labels
+        meleeLabel = new Label("Melee x 1", skin, "small");   // Updated melee label
+        gunLabel = new Label("Gun: 0", skin, "small");       // Updated gun label
 
         table.add(heartImage).size(heartSideLength).pad(5);
         table.add(healthLabel).padLeft(10).left();
         labels.add(healthLabel);
 
-
         table.row().padTop(10);
         table.add(speedImage).size(speedSideLength).pad(5);
         table.add(speedProgressBar).padLeft(10).left().width(200);
 
-        //Don't know if values are correct, may overlap
         table.row().padTop(10);
         table.add(damageImage).size(damageSideLength).pad(5);
         table.add(damageProgressBar).padLeft(10).left().width(200);
@@ -158,29 +168,33 @@ public class PlayerStatsDisplay extends UIComponent {
         table.add(armorProgressBar).padLeft(10).left().width(200);
 
         table.row().padTop(10);
-        table.add(pickaxeLabel).colspan(2).padLeft(10).left();
-        labels.add(pickaxeLabel);
+        table.add(meleeLabel).colspan(2).padLeft(10).left();
+        labels.add(meleeLabel);
+
+        // Add the gun label
         table.row().padTop(10);
-        table.add(shotgunLabel).colspan(2).padLeft(10).left();
+        table.add(gunLabel).colspan(2).padLeft(10).left();
+
         table.row().padTop(10);
         table.add(ammoTable).colspan(2).left().padLeft(2);
         stage.addActor(table);
     }
 
-    public void resize(int width, int height)
-    {
-        if (labels != null)
-            for(Label label : labels)
-                label.setFontScale(width/1100f);
+    public void resize(int width, int height) {
+        if (labels != null) {
+            for (Label label : labels) {
+                label.setFontScale(width / 1100f);
+            }
+        }
     }
-    
+
     @Override
     public void draw(SpriteBatch batch) {
-
+        // Drawing handled automatically by the stage and actors
     }
 
     /**
-     * Updates the player's health on the ui.
+     * Updates the player's health on the UI.
      *
      * @param health player health
      */
@@ -190,22 +204,34 @@ public class PlayerStatsDisplay extends UIComponent {
     }
 
     public void updateMeleeWeaponUI() {
-        CharSequence text = String.format("Pickaxe x %d", 1);
-        pickaxeLabel.setText(text);
-    }
-
-    public void updateRangedWeaponUI(int maxAmmo) {
-        CharSequence text = String.format("Shotgun x %d", 1);
-        shotgunLabel.setText(text);
-
-        currentAmmo = maxAmmo; // Initialize ammo count from WeaponComponent
-        displayAllAmmo();
+        CharSequence text = String.format("Melee x %d", 1);   // Updated melee label
+        meleeLabel.setText(text);
     }
 
     /**
-     * Displays ammo based on the count of the shotgun or other ranged weapon.
-     * This method is called when the shotgun count is greater than 0.
-     * Displays ammo in rows of 8 within a separate ammo table.
+     * Updates the ranged weapon UI.
+     *
+     * @param maxAmmo the maximum ammo count for the weapon.
+     * @param weaponName the name of the weapon (e.g., "Gun").
+     */
+    public void updateRangedWeaponUI(int maxAmmo, String weaponName) {
+        currentAmmo = maxAmmo;  // Initialize ammo count from WeaponComponent
+        displayAllAmmo();
+
+        CharSequence text = String.format("%s x %d", weaponName, 1);
+        gunLabel.setText(text);   // Update gun label
+    }
+
+    /**
+     * Updates the gun label with the specified ammo count.
+     */
+    public void updateGunLabel(int maxAmmo, String weaponName) {
+        CharSequence text = String.format("%s x %d", weaponName, maxAmmo);
+        gunLabel.setText(text);
+    }
+
+    /**
+     * Displays ammo based on the count of the ranged weapon.
      */
     private void displayAllAmmo() {
         ammoTable.clear(); // Clear existing ammo from the ammoTable
@@ -214,12 +240,12 @@ public class PlayerStatsDisplay extends UIComponent {
 
         // Always display ammo up to currentAmmo
         for (int i = 0; i < currentAmmo; i++) {
-            if (itemsInRow == 8) {
-                ammoTable.row().padTop(2f); // Start a new row after 8 ammo items
+            if (itemsInRow == 5) {
+                ammoTable.row().padTop(2f); // Start a new row after 5 ammo items
                 itemsInRow = 0;
             }
             ammoImages.get(i).setVisible(true);
-            ammoTable.add(ammoImages.get(i)).size(screenWidth/45f);
+            ammoTable.add(ammoImages.get(i)).size(screenWidth / 45f);
             itemsInRow++;
         }
 
@@ -228,7 +254,6 @@ public class PlayerStatsDisplay extends UIComponent {
 
     /**
      * Updates the ammo display based on the current ammo count.
-     * Ammo icons beyond the current count will be hidden.
      */
     private void updateAmmoDisplay(int ammoCount) {
         for (int i = 0; i < ammoImages.size(); i++) {
@@ -241,14 +266,11 @@ public class PlayerStatsDisplay extends UIComponent {
     }
 
     /**
-     * Updates the player's speed on the ui.
+     * Updates the player's speed on the UI.
      *
      * @param speedPercentage the player's new speed percentage to update the UI to
      */
     public void updateSpeedPercentageUI(float speedPercentage, String speedType) {
-        //Temporarily commented out in case design team prefers text over a progress bar
-//        CharSequence text = String.format("Speed: %.1f%%", speedPercentage);
-//        speedLabelText.setText(text);
         speedProgressBar.setValue(speedPercentage);
     }
 


### PR DESCRIPTION
# Description

This update addresses an issue where the initial weapon counter incorrectly displayed zero, despite the player already having a weapon equipped. The weapon counter now properly reflects the initial weapon status. Additionally, the initial ammo count has been customized to vary according to different player types, ensuring correct ammo initialization. An issue with ammo shells appearing incorrectly on the map has also been resolved.

Fixes / Closes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

I extensively tested these changes by playing the game for several hours, identifying the issues, and ensuring the fixes worked correctly. After making the changes, I played the game again for an extended period to verify that the weapon counter and ammo behavior functioned as expected, and that the ammo shells no longer appeared incorrectly on the map.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
